### PR TITLE
Add seeders for Permissions and Roles using Command Line Runners

### DIFF
--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
@@ -2,10 +2,7 @@ package com.amalitech.mentorshiptrackr.models;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.UUID;
 
@@ -13,6 +10,7 @@ import java.util.UUID;
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Entity
 @Table(name = "admins")
 public class Admin {

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
@@ -30,6 +30,7 @@ public class Admin {
     @Column(name = "email", nullable = false)
     private String email;
 
+    @Column(name = "password", nullable = false)
     private String password;
 
     @NotBlank(message = "Role is required")

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
 @Entity
 @Table(name = "permissions")
 public class Permission {

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
@@ -1,10 +1,7 @@
 package com.amalitech.mentorshiptrackr.models;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -12,6 +9,7 @@ import java.util.UUID;
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Entity
 @Table(name = "permissions")
 public class Permission {

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Role.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Role.java
@@ -2,10 +2,7 @@ package com.amalitech.mentorshiptrackr.models;
 
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Collection;
 import java.util.Set;
@@ -15,6 +12,7 @@ import java.util.UUID;
 @Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @Entity
 @Table(name = "roles")
 public class Role {

--- a/src/main/java/com/amalitech/mentorshiptrackr/repositories/PermissionRepository.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/repositories/PermissionRepository.java
@@ -1,0 +1,10 @@
+package com.amalitech.mentorshiptrackr.repositories;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PermissionRepository extends JpaRepository<Permission, UUID> {
+    Permission findByNameIgnoreCase(String permissionName);
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/repositories/RoleRepository.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/repositories/RoleRepository.java
@@ -1,0 +1,10 @@
+package com.amalitech.mentorshiptrackr.repositories;
+
+import com.amalitech.mentorshiptrackr.models.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+    Role findByNameIgnoreCase(String roleName);
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/seeders/PermissionSeeder.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/seeders/PermissionSeeder.java
@@ -1,0 +1,49 @@
+package com.amalitech.mentorshiptrackr.seeders;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import com.amalitech.mentorshiptrackr.services.PermissionService;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+
+import org.slf4j.Logger;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Order(1)
+public class PermissionSeeder implements CommandLineRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(PermissionSeeder.class);
+
+    @Autowired
+    private PermissionService permissionService;
+
+    @Override
+    public void run(String... args) throws Exception {
+        logger.info("The Permission seeder is running");
+
+        List<Permission> permissions = new ArrayList<>();
+        permissions.add(
+                Permission.builder()
+                        .name("Manage mentorship")
+                        .description("create, view, update and delete on mentorship(advisors and advisees)")
+                        .build()
+        );
+        permissions.add(
+                Permission.builder()
+                        .name("View mentorship")
+                        .description("view mentorship only")
+                        .build()
+        );
+
+        for (Permission permission : permissions) {
+            permission = permissionService.createPermissionIfNotExists(permission);
+            if (permission != null)
+                logger.info("%s permission has been seeded successfully".formatted(permission.getName()));
+        }
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/seeders/RoleSeeder.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/seeders/RoleSeeder.java
@@ -1,0 +1,62 @@
+package com.amalitech.mentorshiptrackr.seeders;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import com.amalitech.mentorshiptrackr.models.Role;
+import com.amalitech.mentorshiptrackr.services.PermissionService;
+import com.amalitech.mentorshiptrackr.services.RoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+@Order(2)
+public class RoleSeeder implements CommandLineRunner {
+    @Autowired
+    private PermissionService permissionService;
+
+    @Autowired
+    private RoleService roleService;
+
+    private static final Logger logger = LoggerFactory.getLogger(RoleSeeder.class);
+
+    @Override
+    public void run(String... args) throws Exception {
+        List<Role> roles = new ArrayList<>();
+
+        roles.add(Role.builder()
+                .name("Administrator")
+                .description("Perform all actions")
+                .build()
+        );
+
+        Set<Permission> mentorshipManagerPermissions = new HashSet<>();
+
+        Permission manageMentorshipPermission = permissionService.findByNameIgnoreCase("manage mentorship");
+        Permission viewMentorshipPermission = permissionService.findByNameIgnoreCase("view mentorship");
+
+        mentorshipManagerPermissions.add(manageMentorshipPermission);
+        mentorshipManagerPermissions.add(viewMentorshipPermission);
+
+        roles.add(Role.builder()
+                .name("Mentorship manager")
+                .description("Perform mentorship associated CRUD actions")
+                .permissions(mentorshipManagerPermissions)
+                .build()
+        );
+
+        for (Role role : roles) {
+            role = roleService.createRoleIfNotExists(role);
+
+            if (role != null)
+                logger.info("%s role has been seeded successfully".formatted(role.getName()));
+        }
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/services/PermissionService.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/services/PermissionService.java
@@ -1,0 +1,11 @@
+package com.amalitech.mentorshiptrackr.services;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import jakarta.transaction.Transactional;
+
+public interface PermissionService {
+    @Transactional
+    Permission createPermissionIfNotExists(Permission permission);
+
+    Permission findByNameIgnoreCase(String roleName);
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/services/PermissionServiceImpl.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/services/PermissionServiceImpl.java
@@ -1,0 +1,32 @@
+package com.amalitech.mentorshiptrackr.services;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import com.amalitech.mentorshiptrackr.repositories.PermissionRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PermissionServiceImpl implements PermissionService {
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    @Override
+    @Transactional
+    public Permission createPermissionIfNotExists(Permission permission) {
+        Permission permissionInDb  = permissionRepository.findByNameIgnoreCase(permission.getName());
+
+        if (permissionInDb == null) {
+            permissionInDb = permission;
+            permissionRepository.save(permission);
+        }
+
+        return permissionInDb;
+    }
+
+    @Override
+    public Permission findByNameIgnoreCase(String roleName) {
+        return permissionRepository.findByNameIgnoreCase(roleName);
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/services/RoleService.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/services/RoleService.java
@@ -1,0 +1,9 @@
+package com.amalitech.mentorshiptrackr.services;
+
+import com.amalitech.mentorshiptrackr.models.Role;
+import jakarta.transaction.Transactional;
+
+public interface RoleService {
+    @Transactional
+    Role createRoleIfNotExists(Role role);
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/services/RoleServiceImpl.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/services/RoleServiceImpl.java
@@ -1,0 +1,26 @@
+package com.amalitech.mentorshiptrackr.services;
+
+import com.amalitech.mentorshiptrackr.models.Role;
+import com.amalitech.mentorshiptrackr.repositories.RoleRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleServiceImpl implements RoleService {
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Override
+    @Transactional
+    public Role createRoleIfNotExists(Role role) {
+        Role roleInDB = roleRepository.findByNameIgnoreCase(role.getName());
+
+        if (roleInDB == null) {
+            roleInDB = role;
+            roleRepository.save(roleInDB);
+        }
+
+        return roleInDB;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/db/migration/V6__Make_password_field_on_admin_not_null.sql
+++ b/src/main/resources/db/migration/V6__Make_password_field_on_admin_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE admins
+    ALTER COLUMN password SET NOT NULL;


### PR DESCRIPTION
On application startup seed the database roles and permissions tables with following Roles and Permissions

### Roles
- Administrator
- Mentorship manager

### Permissions
- Manage mentorship
- View mentorship

