### PR TITLE
Add createdAt and updatedAt audit data to model entities

### DIFF
--- a/src/main/java/com/amalitech/mentorshiptrackr/models/AuditData.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/AuditData.java
@@ -1,0 +1,26 @@
+package com.amalitech.mentorshiptrackr.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SourceType;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@Embeddable
+public class AuditData {
+    @CreationTimestamp(source = SourceType.DB)
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp(source = SourceType.DB)
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}
+
+// TODO: add createdBy and lastModifiedBy fields once you set up Spring security

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Permission.java
@@ -26,4 +26,7 @@ public class Permission {
 
     @ManyToMany(mappedBy = "permissions", fetch = FetchType.EAGER)
     private Set<Role> roles;
+
+    @Embedded
+    private AuditData auditData;
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Role.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Role.java
@@ -8,7 +8,8 @@ import java.util.Set;
 import java.util.UUID;
 
 
-@Getter @Setter
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -26,12 +27,11 @@ public class Role {
     @Column(name = "description", nullable = false)
     private String description;
 
+    @Embedded
+    private AuditData auditData;
+
     @ManyToMany
-    @JoinTable(
-            name = "roles_permissions",
-            joinColumns = {@JoinColumn(name = "role_id", referencedColumnName = "id")},
-            inverseJoinColumns = {@JoinColumn(name = "permission_id", referencedColumnName = "id")}
-    )
+    @JoinTable(name = "roles_permissions", joinColumns = {@JoinColumn(name = "role_id", referencedColumnName = "id")}, inverseJoinColumns = {@JoinColumn(name = "permission_id", referencedColumnName = "id")})
     private Set<Permission> permissions;
 
     @OneToMany(mappedBy = "role")

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
@@ -31,6 +31,9 @@ public class User {
     private @Column(name = "password", nullable = false)
     String password;
 
+    @Embedded
+    private AuditData auditData;
+
     public User(String username, String email, String password) {
         this.username = username;
         this.email = email;

--- a/src/main/resources/db/migration/V10__Add_created_at_and_updated_at_fields_to_roles_table.sql
+++ b/src/main/resources/db/migration/V10__Add_created_at_and_updated_at_fields_to_roles_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE roles
+    ADD created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();
+
+ALTER TABLE roles
+    ADD updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();

--- a/src/main/resources/db/migration/V11__Add_created_at_and_updated_at_fields_to_permissions_table.sql
+++ b/src/main/resources/db/migration/V11__Add_created_at_and_updated_at_fields_to_permissions_table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE permissions
+    ADD created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();
+ALTER TABLE permissions
+    ADD updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();

--- a/src/main/resources/db/migration/V12__Add_created_at_and_updated_at_fields_to_admins_users_table.sql
+++ b/src/main/resources/db/migration/V12__Add_created_at_and_updated_at_fields_to_admins_users_table.sql
@@ -1,0 +1,11 @@
+ALTER TABLE admins
+    ADD created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();
+
+ALTER TABLE admins
+    ADD updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();
+
+ALTER TABLE users
+    ADD created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();
+
+ALTER TABLE users
+    ADD updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL default now();


### PR DESCRIPTION
Added an AuditData embeddable that provides createdAt, updatedAt fields
for the Role, Permission, User and Admin entities.

