### PR TITLE
Add endpoint to allow creation of admin accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.github.cdimascio/dotenv-java -->
-        <dependency>
-            <groupId>io.github.cdimascio</groupId>
-            <artifactId>dotenv-java</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>

--- a/src/main/java/com/amalitech/mentorshiptrackr/config/SecurityConfig.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/config/SecurityConfig.java
@@ -1,14 +1,34 @@
 package com.amalitech.mentorshiptrackr.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @Configuration
 @EnableWebMvc
 public class SecurityConfig {
+
+    @Value("${api.endpoint.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults());
+
+        return httpSecurity.build();
+    }
 
     @Bean
     public PasswordEncoder encoder() {

--- a/src/main/java/com/amalitech/mentorshiptrackr/controllers/AdminController.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/controllers/AdminController.java
@@ -1,0 +1,28 @@
+package com.amalitech.mentorshiptrackr.controllers;
+
+import com.amalitech.mentorshiptrackr.dto.AdminDTO;
+import com.amalitech.mentorshiptrackr.dto.AdminMapper;
+import com.amalitech.mentorshiptrackr.dto.CreateAdminDTO;
+import com.amalitech.mentorshiptrackr.models.Admin;
+import com.amalitech.mentorshiptrackr.services.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/admins")
+@RestController
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+    private final AdminMapper adminMapper;
+
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
+    public AdminDTO addNewAdmin(@RequestBody @Valid CreateAdminDTO adminDTO) {
+        Admin admin = (Admin) userService.addNewAdminAccount(adminMapper.toEntity(adminDTO));
+
+        return adminMapper.toDTO(admin);
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/dto/AdminDTO.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/dto/AdminDTO.java
@@ -1,0 +1,23 @@
+package com.amalitech.mentorshiptrackr.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDTO {
+    private UUID id;
+    private String userName;
+    private String firstName;
+    private String email;
+    private Instant createdAt;
+    private Instant updatedAt;
+    private String role;
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/dto/AdminMapper.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/dto/AdminMapper.java
@@ -1,0 +1,34 @@
+package com.amalitech.mentorshiptrackr.dto;
+
+import com.amalitech.mentorshiptrackr.models.Admin;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdminMapper {
+
+    public AdminDTO toDTO(Admin entity) {
+        AdminDTO dto = new AdminDTO();
+
+        dto.setId(entity.getId());
+        dto.setUserName(entity.getUsername());
+        dto.setFirstName(entity.getFirstName());
+        dto.setEmail(entity.getEmail());
+        dto.setCreatedAt(entity.getAuditData().getCreatedAt());
+        dto.setUpdatedAt(entity.getAuditData().getUpdatedAt());
+        dto.setRole(entity.getRole().getName());
+
+        return dto;
+    }
+
+    public Admin toEntity(CreateAdminDTO dto) {
+        Admin entity = new Admin();
+
+        entity.setUsername(dto.getUsername());
+        entity.setFirstName(dto.getFirstName());
+        entity.setEmail(dto.getEmail());
+
+        return entity;
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/dto/CreateAdminDTO.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/dto/CreateAdminDTO.java
@@ -1,0 +1,29 @@
+package com.amalitech.mentorshiptrackr.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAdminDTO {
+    @NotBlank(message = "username is required.")
+    @Size(min = 3, message = "username should have at least 3 characters.")
+    private String username;
+
+    @NotBlank(message = "firstName is required.")
+    private String firstName;
+
+    @NotBlank
+    @Email(message = "email is required.")
+    private String email;
+
+    @NotBlank
+    private String role;
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/dto/UserPrincipal.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/dto/UserPrincipal.java
@@ -1,0 +1,57 @@
+package com.amalitech.mentorshiptrackr.dto;
+
+import com.amalitech.mentorshiptrackr.models.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class UserPrincipal implements UserDetails {
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Stream.of(user.getRole().getName()).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/exceptions/APIErrorInfo.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/exceptions/APIErrorInfo.java
@@ -1,0 +1,13 @@
+package com.amalitech.mentorshiptrackr.exceptions;
+
+
+import lombok.Getter;
+
+@Getter
+public class APIErrorInfo {
+    private final String errorMessage;
+
+    public APIErrorInfo(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.amalitech.mentorshiptrackr.exceptions;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public APIErrorInfo handleEntityAlreadyExistsException(HttpServletRequest request, EntityAlreadyExistsException exception) {
+        return new APIErrorInfo(exception.getMessage());
+    }
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public Map<String, String> handleInvalidArgumentException(HttpServletRequest request, MethodArgumentNotValidException exception) {
+        Map<String, String> errorMap = new HashMap<>();
+        exception.getBindingResult().getFieldErrors()
+                .forEach(error -> errorMap.put(error.getField(), error.getDefaultMessage()));
+
+        return errorMap;
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public APIErrorInfo handleAllOtherExceptions(HttpServletRequest request, Exception exception) {
+        return new APIErrorInfo(exception.getMessage());
+    }
+}

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
@@ -22,4 +22,9 @@ public class Admin extends User {
         super(username, email, password, role);
         this.firstName = firstName;
     }
+
+    public Admin(String username, String firstName, String email, String password) {
+        super(username, email, password);
+        this.firstName = firstName;
+    }
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/Admin.java
@@ -1,6 +1,8 @@
 package com.amalitech.mentorshiptrackr.models;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -16,13 +18,8 @@ public class Admin extends User {
     @Column(name = "first_name", nullable = false)
     private String firstName;
 
-    @ManyToOne
-    @JoinColumn(name = "role_id", nullable = false)
-    private Role role;
-
     public Admin(String username, String firstName, String email, String password, Role role) {
-        super(username, email, password);
+        super(username, email, password, role);
         this.firstName = firstName;
-        this.role = role;
     }
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
@@ -9,7 +9,8 @@ import lombok.Setter;
 
 import java.util.UUID;
 
-@Getter @Setter
+@Getter
+@Setter
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 @AllArgsConstructor
 @NoArgsConstructor
@@ -34,9 +35,14 @@ public class User {
     @Embedded
     private AuditData auditData;
 
-    public User(String username, String email, String password) {
+    @ManyToOne
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    public User(String username, String email, String password, Role role) {
         this.username = username;
         this.email = email;
         this.password = password;
+        this.role = role;
     }
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/models/User.java
@@ -45,4 +45,10 @@ public class User {
         this.password = password;
         this.role = role;
     }
+
+    public User(String username, String email, String password) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/repositories/UserRepository.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/repositories/UserRepository.java
@@ -3,6 +3,7 @@ package com.amalitech.mentorshiptrackr.repositories;
 import com.amalitech.mentorshiptrackr.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
@@ -10,4 +11,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByUsername(String username);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByUsername(String username);
+
+
 }

--- a/src/main/java/com/amalitech/mentorshiptrackr/seeders/AdminSeeder.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/seeders/AdminSeeder.java
@@ -2,8 +2,6 @@ package com.amalitech.mentorshiptrackr.seeders;
 
 import com.amalitech.mentorshiptrackr.exceptions.EntityAlreadyExistsException;
 import com.amalitech.mentorshiptrackr.models.Admin;
-import com.amalitech.mentorshiptrackr.models.Role;
-import com.amalitech.mentorshiptrackr.services.RoleService;
 import com.amalitech.mentorshiptrackr.services.UserService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -20,8 +18,6 @@ import org.springframework.stereotype.Component;
 public class AdminSeeder implements CommandLineRunner {
     private static final Logger logger = LoggerFactory.getLogger(AdminSeeder.class);
 
-    private final RoleService roleService;
-
     private final UserService userService;
 
     private final Environment environment;
@@ -29,14 +25,11 @@ public class AdminSeeder implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
 
-        Role adminRole = roleService.findRoleByNameIgnoreCase("Administrator");
-
         Admin admin = new Admin(
                 environment.getProperty("SEEDED_ADMIN_USERNAME"),
                 environment.getProperty("SEEDED_ADMIN_FIRST_NAME"),
                 environment.getProperty("SEEDED_ADMIN_EMAIL"),
-                environment.getProperty("SEEDED_ADMIN_PASSWORD"),
-                adminRole
+                environment.getProperty("SEEDED_ADMIN_PASSWORD")
         );
 
         try {

--- a/src/main/java/com/amalitech/mentorshiptrackr/utils/PasswordGenerator.java
+++ b/src/main/java/com/amalitech/mentorshiptrackr/utils/PasswordGenerator.java
@@ -1,0 +1,54 @@
+package com.amalitech.mentorshiptrackr.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public abstract class PasswordGenerator {
+    private static final String LOWER_CASE = "abcdefghijklmnopqrstuvwxyz";
+    private static final String UPPER_CASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String NUMBERS = "0123456789";
+    private static final String SPECIAL_CHARACTERS = "!@#$%^&*()-_=+[{]};:'\",<.>/?";
+
+    private static final String ALL_CHARACTERS = LOWER_CASE + UPPER_CASE + NUMBERS + SPECIAL_CHARACTERS;
+    private static final SecureRandom random = new SecureRandom();
+
+    private PasswordGenerator() {
+    }
+
+    public static String generatePassword(int length) throws IllegalArgumentException {
+        if (length < 8) {
+            throw new IllegalArgumentException("Password length must be at least 8 characters");
+        }
+
+        StringBuilder password = new StringBuilder(length);
+
+        // Generate at least one character from each character type
+        password.append(getRandomCharacter(LOWER_CASE));
+        password.append(getRandomCharacter(UPPER_CASE));
+        password.append(getRandomCharacter(NUMBERS));
+        password.append(getRandomCharacter(SPECIAL_CHARACTERS));
+
+        // Generate remaining characters randomly from all character types
+        for (int i = 4; i < length; i++) {
+            password.append(getRandomCharacter(ALL_CHARACTERS));
+        }
+
+        // Shuffle the generated password
+        char[] passwordArray = password.toString().toCharArray();
+        for (int i = passwordArray.length - 1; i > 0; i--) {
+            int index = random.nextInt(i + 1);
+            char temp = passwordArray[index];
+            passwordArray[index] = passwordArray[i];
+            passwordArray[i] = temp;
+        }
+
+        return new String(passwordArray);
+    }
+
+    private static char getRandomCharacter(String characters) {
+        int index = random.nextInt(characters.length());
+        return characters.charAt(index);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   application:
     name: MentorshipTrackr
@@ -26,6 +25,9 @@ spring:
     enabled: true
     baseline-description: "Init"
     baseline-version: 0
+api:
+  endpoint:
+    base-url: /api/v1
 
 logging:
   level:

--- a/src/main/resources/db/migration/V13__Alter_users_table_add_role.sql
+++ b/src/main/resources/db/migration/V13__Alter_users_table_add_role.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD role_id UUID;

--- a/src/test/java/com/amalitech/mentorshiptrackr/services/PermissionServiceTest.java
+++ b/src/test/java/com/amalitech/mentorshiptrackr/services/PermissionServiceTest.java
@@ -1,0 +1,105 @@
+package com.amalitech.mentorshiptrackr.services;
+
+import com.amalitech.mentorshiptrackr.models.Permission;
+import com.amalitech.mentorshiptrackr.repositories.PermissionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PermissionServiceTest {
+    // dependency -> PermissionRepository
+    // dependant -> PermissionService
+
+    @Mock
+    PermissionRepository permissionRepository;
+
+    @InjectMocks
+    PermissionServiceImpl permissionService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void testFindByNameIgnoreCaseSuccess() {
+        // given: setup inputs and targets
+        Permission permission1 = Permission.builder()
+                .id(UUID.randomUUID())
+                .name("Read admin list")
+                .description("View list of all admins in system.").build();
+
+        given(permissionRepository
+                .findByNameIgnoreCase("Read admin list"))
+                .willReturn(permission1);
+
+        // when: act on the target
+        Permission permission = permissionService.findByNameIgnoreCase("Read admin list");
+
+        // then
+        assertThat(permission.getId()).isEqualTo(permission1.getId());
+        assertThat(permission.getName()).isEqualTo(permission1.getName());
+        assertThat(permission.getDescription()).isEqualTo(permission1.getDescription());
+        verify(permissionRepository, times(1))
+                .findByNameIgnoreCase("Read admin list");
+    }
+
+    @Test
+    void testAddNewPermissionSuccess() {
+        // given: setup inputs and targets
+        Permission permission = Permission.builder()
+                .id(UUID.randomUUID())
+                .name("Read admin list")
+                .description("View list of all admins in system.").build();
+
+        given(permissionRepository.save(permission)).willReturn(permission);
+
+        // when: act on the target
+        Permission new_permission = permissionService.addNewPermission(permission);
+
+        // then
+        assertThat(new_permission.getId()).isEqualTo(permission.getId());
+        assertThat(new_permission.getName()).isEqualTo(permission.getName());
+        assertThat(new_permission.getDescription()).isEqualTo(permission.getDescription());
+        verify(permissionRepository, times(1)).save(permission);
+    }
+
+    @Test
+    void permissionExists() {
+        // given
+        Set<Permission> permissions = new HashSet<>();
+        Permission permission1 = Permission.builder()
+                .id(UUID.randomUUID())
+                .name("Read admin list")
+                .description("View list of all admins in system.").build();
+        Permission permission2 = Permission.builder()
+                .id(UUID.randomUUID())
+                .name("Add new admin")
+                .description("Add a new administrator to the system").build();
+
+        given(permissionRepository.existsByNameIgnoreCase("read admin list")).willReturn(true);
+
+        // when
+        boolean permissionExists = permissionService.permissionExists("read admin list");
+
+        // then
+        assertThat(permissionExists).isTrue();
+    }
+}


### PR DESCRIPTION
- feat: Move the roles column from Admin entity to the upper User entity
- test: Add tests for PermissionServiceImpl
- feat: Add AdminDTO and CreateAdminDTO
- feat: Add UserPrinciple to return user details to the auth manager
- feat: Implement the UserDetailsService and loadUserByUsername
- feat: Add security filter chain
- feat: Add password generator to generate random password for accounts
- feat: Add new constructor
- feat: Set the role for admin in the service.
- feat: Add a new constructor.
- feat: Add mapper for converting data from dto to entity and vice versa
- feat: Add Controller for adding admin accounts
- feat: Add global exception handler
